### PR TITLE
fix/#2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="uk.co.brightec.kbarcode.app">
 
-    <!-- This sample app would require uses to have a camera
+    <!-- This sample app would require users to have a camera
     https://developer.android.com/guide/topics/manifest/uses-feature-element -->
     <uses-feature
         android:name="android.hardware.camera"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="uk.co.brightec.kbarcode.app">
 
-    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" />
+    <uses-feature android:name="android.hardware.camera.autofocus" />
 
     <application
         android:name=".Application"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,8 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="uk.co.brightec.kbarcode.app">
 
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
+    <!-- This sample app would require uses to have a camera
+    https://developer.android.com/guide/topics/manifest/uses-feature-element -->
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="true" />
 
     <application
         android:name=".Application"

--- a/kbarcode/src/main/AndroidManifest.xml
+++ b/kbarcode/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
     <application>
 


### PR DESCRIPTION
Changed the lib to declare the camera features as optional. Then changed the sample app to declare them as required. Also removed the uses-permission CAMERA from the sample app, as its already stated in the lib and does not need to be re-declared. An update has also been made to the wiki to reflect this change - see https://github.com/brightec/KBarcode/wiki/Reference#manifest

Fix for #2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/3)
<!-- Reviewable:end -->
