### PR TITLE
fix/#4

### DIFF
--- a/kbarcode/src/test/java/uk/co/brightec/kbarcode/camera/Camera2SourceTest.kt
+++ b/kbarcode/src/test/java/uk/co/brightec/kbarcode/camera/Camera2SourceTest.kt
@@ -13,6 +13,7 @@ import android.view.Surface
 import androidx.test.filters.SmallTest
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doNothing
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
@@ -95,6 +96,21 @@ internal class Camera2SourceTest {
         verify(cameraManager, never()).openCamera(
             any(), any(), anyOrNull<Handler>()
         )
+    }
+
+    @Test
+    fun noCameraId__start__error() {
+        // GIVEN
+        doReturn(null).whenever(cameraSource).selectCamera()
+
+        // WHEN
+        val listener = mock<OnCameraReadyListener>()
+        cameraSource.start(mock(), listener)
+
+        // THEN
+        val captor = argumentCaptor<CameraException>()
+        verify(listener).onCameraFailure(captor.capture())
+        assertTrue(captor.firstValue is CameraServiceException)
     }
 
     @Test


### PR DESCRIPTION
Changed the selectCamera() method to return optional. Null indicating that there were no cameras in the id list. This is then handled within the start method, by calling the listener with an error. Added a test to accompany this change

This fixes #4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/6)
<!-- Reviewable:end -->
