### PR TITLE
Fix/#13 - Camera Opening

### DIFF
--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
@@ -95,6 +95,10 @@ class BarcodeScanner internal constructor(
             Timber.d("Attempted Camera2Source.start(), which has already been started")
             return
         }
+        if (cameraSource.isOpening()) {
+            Timber.d("Attempted Camera2Source.start(), which is currently opening")
+            return
+        }
 
         frameProcessor.barcodes.observeForever(barcodesObserver)
         startCameraSource()

--- a/kbarcode/src/test/java/uk/co/brightec/kbarcode/BarcodeScannerTest.kt
+++ b/kbarcode/src/test/java/uk/co/brightec/kbarcode/BarcodeScannerTest.kt
@@ -155,6 +155,38 @@ internal class BarcodeScannerTest {
     }
 
     @Test
+    fun cameraIsStarted__start__resumeProcessing_doesntAddObserver_doesntStartCameraSource() {
+        doNothing().whenever(barcodeScanner).startCameraSource()
+
+        // GIVEN
+        whenever(cameraSource.isStarted()).thenReturn(true)
+
+        // WHEN
+        barcodeScanner.start()
+
+        // THEN
+        assertFalse(barcodeScanner.pauseProcessing)
+        verify(frameProcessor.barcodes, never()).observeForever(any())
+        verify(barcodeScanner, never()).startCameraSource()
+    }
+
+    @Test
+    fun cameraIsOpening__start__resumeProcessing_doesntAddObserver_doesntStartCameraSource() {
+        doNothing().whenever(barcodeScanner).startCameraSource()
+
+        // GIVEN
+        whenever(cameraSource.isOpening()).thenReturn(true)
+
+        // WHEN
+        barcodeScanner.start()
+
+        // THEN
+        assertFalse(barcodeScanner.pauseProcessing)
+        verify(frameProcessor.barcodes, never()).observeForever(any())
+        verify(barcodeScanner, never()).startCameraSource()
+    }
+
+    @Test
     fun processingResumed__resume__resumeProcessing() {
         // GIVEN
         barcodeScanner.pauseProcessing = false


### PR DESCRIPTION
We have added the ability to track whether the camera is currently opening. This means it is now safe to call `start()`, even if the camera is currently being opened.

This will resolve issue #13 because now when `start()` gets called twice in quick succession due to marshmallow permission dialog behaviours, the second call will get ignored.

You can detect when this behaviour occurs in the logs - look for `Attempted Camera2Source.start(), which is currently opening`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/14)
<!-- Reviewable:end -->
