### PR TITLE
fix/LiveData

### DIFF
--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/processor/BarcodeProcessorSingle.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/processor/BarcodeProcessorSingle.kt
@@ -43,6 +43,7 @@ internal class BarcodeProcessorSingle(
     override fun stop() {
         super.stop()
         detector.close()
+        _barcodes.value = emptyList()
     }
 
     override fun detectInImage(image: FirebaseVisionImage): Task<List<FirebaseVisionBarcode>> =


### PR DESCRIPTION
When the processor receives the stop command. It should empty its list of barcodes, in order that if it starts again, it does not publicise the old values.

Since the `BarcodeScanner` has an empty check, it means when the `BarcodeScanner.barcodesObserver` gets attached again, it will not publicise the old values again.

This was raised in #24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/25)
<!-- Reviewable:end -->
