### PR TITLE
fix/ClosingImageReader

### DIFF
--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
@@ -115,8 +115,8 @@ class BarcodeScanner internal constructor(
     override fun release() {
         frameProcessor.barcodes.removeObserver(barcodesObserver)
         frameProcessor.stop()
-        cameraSource.release()
         imageReader?.close()
+        cameraSource.release()
     }
 
     override fun setCameraFacing(facing: Int) {


### PR DESCRIPTION
The ImageReader should be closed before the camera, otherwise, with very specific timing, there could be no cameraFacing during the the onImageAvailable callback

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/33)
<!-- Reviewable:end -->
