### PR TITLE
Fix crash

### DIFF
--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
@@ -198,9 +198,7 @@ class BarcodeScanner internal constructor(
                 width = it.width,
                 height = it.height,
                 rotation = getRotationCompensation(),
-                cameraFacing = cameraSource.getCameraFacing() ?: throw IllegalStateException(
-                    "Processing image without camera facing"
-                )
+                cameraFacing = cameraSource.getCameraFacing()
             )
             frameProcessor.process(image, frameMetadata)
         }, null)

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UnusedImports") // Used in javadoc
 package uk.co.brightec.kbarcode.camera
 
 import android.hardware.camera2.CameraCharacteristics

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
@@ -7,5 +7,5 @@ data class FrameMetadata(
     val width: Int,
     val height: Int,
     val rotation: Int,
-    val cameraFacing: Int
+    val cameraFacing: Int?
 )

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
@@ -1,7 +1,25 @@
 package uk.co.brightec.kbarcode.camera
 
+import android.hardware.camera2.CameraCharacteristics
+import com.google.firebase.ml.vision.common.FirebaseVisionImageMetadata
+import uk.co.brightec.kbarcode.BarcodeScanner
 import uk.co.brightec.kbarcode.util.OpenForTesting
 
+/**
+ * Holds metadata useful when implementing a `BarcodeComparator`
+ *
+ * @property width
+ *   The width of the image
+ * @property height
+ *   The height of the image
+ * @property rotation
+ *   The rotation relative to the device's current orientation
+ *   @see BarcodeScanner.getRotationCompensation
+ *   @see FirebaseVisionImageMetadata
+ * @property cameraFacing
+ *   The direction the camera is facing. Optional because not all devices report this value.
+ *   @see CameraCharacteristics.LENS_FACING
+ */
 @OpenForTesting
 data class FrameMetadata(
     val width: Int,

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/FrameMetadata.kt
@@ -17,7 +17,8 @@ import uk.co.brightec.kbarcode.util.OpenForTesting
  *   @see BarcodeScanner.getRotationCompensation
  *   @see FirebaseVisionImageMetadata
  * @property cameraFacing
- *   The direction the camera is facing. Optional because not all devices report this value.
+ *   The direction the camera is facing. Optional because some devices fail to report this value
+ *   reliably every time, but usually expected to be present.
  *   @see CameraCharacteristics.LENS_FACING
  */
 @OpenForTesting


### PR DESCRIPTION
Fixes the "Processing image without camera facing" crash by making this property optional (we don't use it).

Tested by deploying this change via mavenLocal to a client project and manually tested barcode scanning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/41)
<!-- Reviewable:end -->
