### PR TITLE
Feature: Tap to Focus

### DIFF
--- a/app/src/main/java/uk/co/brightec/kbarcode/app/ProgrammaticActivity.kt
+++ b/app/src/main/java/uk/co/brightec/kbarcode/app/ProgrammaticActivity.kt
@@ -42,6 +42,7 @@ internal class ProgrammaticActivity : AppCompatActivity(),
                 )
                 .barcodesSort(null)
                 .scaleType(BarcodeView.CENTER_INSIDE)
+                .clearFocusDelay(BarcodeView.CLEAR_FOCUS_DELAY_DEFAULT)
                 .build()
         )
         frame_container.addView(barcodeView)

--- a/app/src/main/res/layout/activity_xml.xml
+++ b/app/src/main/res/layout/activity_xml.xml
@@ -19,7 +19,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:scaleType="centerInside"
-        app:sort="none" />
+        app:sort="none"
+        app:clearFocusDelay="2000"/>
 
     <TextView
         android:id="@+id/text_barcodes"

--- a/kbarcode/src/androidTest/java/uk/co/brightec/kbarcode/BarcodeScannerAndroidTest.kt
+++ b/kbarcode/src/androidTest/java/uk/co/brightec/kbarcode/BarcodeScannerAndroidTest.kt
@@ -1,0 +1,297 @@
+package uk.co.brightec.kbarcode
+
+import android.graphics.Rect
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.params.MeteringRectangle
+import android.view.WindowManager
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.filters.MediumTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.timeout
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.co.brightec.kbarcode.camera.Camera2Source
+import uk.co.brightec.kbarcode.processor.BarcodeImageProcessor
+
+@MediumTest
+internal class BarcodeScannerAndroidTest {
+
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private lateinit var cameraSource: Camera2Source
+    private lateinit var windowManager: WindowManager
+    private lateinit var frameProcessor: BarcodeImageProcessor
+
+    private lateinit var barcodeScanner: BarcodeScanner
+
+    @Before
+    fun before() {
+        cameraSource = mock()
+        windowManager = mock()
+        frameProcessor = mock {
+            on { barcodes } doReturn mock()
+        }
+
+        barcodeScanner = spy(
+            BarcodeScanner(
+                cameraSource = cameraSource, windowManager = windowManager,
+                frameProcessor = frameProcessor
+            )
+        )
+    }
+
+    @Test
+    fun params_cameraBack_rotComp0__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_BACK)
+        doReturn(0).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(1, result[0].x)
+        assertEquals(2, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun params_cameraBack_rotComp90__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_BACK)
+        doReturn(90).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(2, result[0].x)
+        assertEquals(99, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun params_cameraBack_rotComp180__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_BACK)
+        doReturn(180).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(99, result[0].x)
+        assertEquals(98, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun params_cameraBack_rotComp270__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_BACK)
+        doReturn(270).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(98, result[0].x)
+        assertEquals(1, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun params_cameraFront_rotComp0__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_FRONT)
+        doReturn(0).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(99, result[0].x)
+        assertEquals(2, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun params_cameraFront_rotComp90__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_BACK)
+        doReturn(90).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(2, result[0].x)
+        assertEquals(99, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun params_cameraFront_rotComp180__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_BACK)
+        doReturn(180).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(99, result[0].x)
+        assertEquals(98, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun params_cameraFront_rotComp270__calculateFocusRegions__asExpected() {
+        // GIVEN
+        val viewWidth = 1000
+        val viewHeight = 1000
+        val touchX = 10F
+        val touchY = 20F
+        val rect = Rect(0, 0, 100, 100)
+        whenever(cameraSource.getCameraSensorInfoActiveArraySize()).doReturn(rect)
+        whenever(cameraSource.getCameraFacing()).doReturn(CameraCharacteristics.LENS_FACING_BACK)
+        doReturn(270).whenever(barcodeScanner).getRotationCompensation()
+
+        // WHEN
+        val result = barcodeScanner.calculateFocusRegions(
+            viewWidth = viewWidth, viewHeight = viewHeight, touchX = touchX, touchY = touchY
+        )
+
+        // THEN
+        assertEquals(1, result!!.size)
+        assertEquals(98, result[0].x)
+        assertEquals(1, result[0].y)
+        assertEquals(5, result[0].width)
+        assertEquals(5, result[0].height)
+        assertEquals(MeteringRectangle.METERING_WEIGHT_MAX, result[0].meteringWeight)
+    }
+
+    @Test
+    fun delayNever__scheduleClearFocusRegions__nothing() {
+        // GIVEN
+        val delay = BarcodeView.CLEAR_FOCUS_DELAY_NEVER
+
+        // WHEN
+        barcodeScanner.scheduleClearFocusRegions(delay)
+
+        // THEN
+        verify(cameraSource, never()).clearFocusRegions()
+    }
+
+    @Test
+    fun delay_cameraNotStarted__scheduleClearFocusRegions__clears() {
+        // GIVEN
+        val delay = 0L
+        whenever(cameraSource.isStarted()).doReturn(false)
+
+        // WHEN
+        barcodeScanner.scheduleClearFocusRegions(delay)
+
+        // THEN
+        verify(cameraSource, timeout(50).times(0)).clearFocusRegions()
+    }
+
+    @Test
+    fun delay_cameraStarted__scheduleClearFocusRegions__clears() {
+        // GIVEN
+        val delay = 0L
+        whenever(cameraSource.isStarted()).doReturn(true)
+
+        // WHEN
+        barcodeScanner.scheduleClearFocusRegions(delay)
+
+        // THEN
+        verify(cameraSource, timeout(50)).clearFocusRegions()
+    }
+}

--- a/kbarcode/src/androidTest/java/uk/co/brightec/kbarcode/BarcodeViewTest.kt
+++ b/kbarcode/src/androidTest/java/uk/co/brightec/kbarcode/BarcodeViewTest.kt
@@ -144,6 +144,18 @@ internal class BarcodeViewTest {
     }
 
     @Test
+    fun delay_setClearFocusDelay_callsBarcodeScanner() {
+        // GIVEN
+        val delay = 1234L
+
+        // WHEN
+        barcodeView.setClearFocusDelay(delay)
+
+        // THEN
+        verify(barcodeScanner).setClearFocusDelay(delay)
+    }
+
+    @Test
     fun attr0__cameraFacingAttrConvert__front() {
         // GIVEN
         val attr = 0

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
@@ -30,7 +30,7 @@ import uk.co.brightec.kbarcode.processor.OnBarcodeListener
 import uk.co.brightec.kbarcode.processor.OnBarcodesListener
 import uk.co.brightec.kbarcode.util.OpenForTesting
 
-
+@Suppress("TooManyFunctions") // Still feels single responsibility
 @OpenForTesting
 class BarcodeScanner internal constructor(
     private val cameraSource: Camera2Source,
@@ -301,6 +301,8 @@ class BarcodeScanner internal constructor(
      * https://androidx.tech/artifacts/camera/camera-core/1.0.0-source/androidx/camera/core/DisplayOrientedMeteringPointFactory.java.html
      * https://androidx.tech/artifacts/camera/camera-core/1.0.0-source/androidx/camera/core/MeteringPointFactory.java.html
      */
+    // The magic numbers in this method are exclusively related to this function
+    @Suppress("MagicNumber")
     @VisibleForTesting
     internal fun calculateFocusRegions(
         viewWidth: Int,
@@ -346,7 +348,7 @@ class BarcodeScanner internal constructor(
 
         // Swap x if it's a mirrored preview
         if (compensateForMirroring) {
-            outputX = outputWidth - outputX;
+            outputX = outputWidth - outputX
         }
 
         // Normalized it to [0, 1]
@@ -394,6 +396,7 @@ class BarcodeScanner internal constructor(
             this[Surface.ROTATION_180] = 180
             this[Surface.ROTATION_270] = 270
         }
+
         @VisibleForTesting
         internal const val TOUCH_AREA_MULTIPLIER = 0.05F
     }

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/KBarcode.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/KBarcode.kt
@@ -45,6 +45,8 @@ class KBarcode {
 
         fun setScaleType(@BarcodeView.ScaleType scaleType: Int)
 
+        fun setClearFocusDelay(delay: Long)
+
         fun setOptions(options: Options) {
             setCameraFacing(options.cameraFacing)
             setCameraFlashMode(options.cameraFlashMode)
@@ -52,6 +54,7 @@ class KBarcode {
             setMinBarcodeWidth(options.minBarcodeWidth)
             setBarcodesSort(options.barcodesSort)
             setScaleType(options.scaleType)
+            setClearFocusDelay(options.clearFocusDelay)
         }
     }
 

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
@@ -81,6 +81,7 @@ data class Options(
         if (minBarcodeWidth != other.minBarcodeWidth) return false
         if (barcodesSort != other.barcodesSort) return false
         if (scaleType != other.scaleType) return false
+        if (clearFocusDelay != other.clearFocusDelay) return false
 
         return true
     }
@@ -92,6 +93,7 @@ data class Options(
         result = 31 * result + minBarcodeWidth.hashCode()
         result = 31 * result + (barcodesSort?.hashCode() ?: 0)
         result = 31 * result + scaleType.hashCode()
+        result = 31 * result + clearFocusDelay.hashCode()
         return result
     }
 }

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
@@ -12,7 +12,8 @@ data class Options(
     val barcodeFormats: IntArray = intArrayOf(Barcode.FORMAT_ALL_FORMATS),
     @Px val minBarcodeWidth: Int? = null,
     val barcodesSort: BarcodeComparator? = null,
-    @BarcodeView.ScaleType val scaleType: Int
+    @BarcodeView.ScaleType val scaleType: Int,
+    val clearFocusDelay: Long
 ) {
 
     class Builder(
@@ -21,7 +22,8 @@ data class Options(
         private var barcodeFormats: IntArray = intArrayOf(Barcode.FORMAT_ALL_FORMATS),
         @Px private var minBarcodeWidth: Int? = null,
         private var barcodesSort: BarcodeComparator? = null,
-        @BarcodeView.ScaleType private var scaleType: Int = BarcodeView.CENTER_INSIDE
+        @BarcodeView.ScaleType private var scaleType: Int = BarcodeView.CENTER_INSIDE,
+        private var clearFocusDelay: Long = BarcodeView.CLEAR_FOCUS_DELAY_DEFAULT
     ) {
 
         fun cameraFacing(cameraFacing: Int) = apply {
@@ -52,13 +54,18 @@ data class Options(
             this.scaleType = scaleType
         }
 
+        fun clearFocusDelay(clearFocusDelay: Long) = apply {
+            this.clearFocusDelay = clearFocusDelay
+        }
+
         fun build() = Options(
             cameraFacing = cameraFacing,
             cameraFlashMode = cameraFlashMode,
             barcodeFormats = barcodeFormats,
             minBarcodeWidth = minBarcodeWidth,
             barcodesSort = barcodesSort,
-            scaleType = scaleType
+            scaleType = scaleType,
+            clearFocusDelay = clearFocusDelay
         )
     }
 

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/Camera2Source.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/Camera2Source.kt
@@ -3,18 +3,24 @@ package uk.co.brightec.kbarcode.camera
 import android.content.Context
 import android.content.Context.CAMERA_SERVICE
 import android.graphics.ImageFormat
+import android.graphics.Rect
 import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
+import android.hardware.camera2.CaptureFailure
 import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.TotalCaptureResult
+import android.hardware.camera2.params.MeteringRectangle
 import android.util.Size
 import android.view.Surface
 import androidx.annotation.RequiresPermission
 import androidx.annotation.VisibleForTesting
 import timber.log.Timber
+import uk.co.brightec.kbarcode.util.OpenForTesting
 
+@OpenForTesting
 @Suppress("TooManyFunctions") // This class does still feels single responsibility
 internal class Camera2Source(
     private val cameraManager: CameraManager
@@ -22,6 +28,10 @@ internal class Camera2Source(
 
     @VisibleForTesting
     internal var cameraDevice: CameraDevice? = null
+    @VisibleForTesting
+    internal var currentSession: CameraCaptureSession? = null
+    @VisibleForTesting
+    internal var currentSurfaces: List<Surface>? = null
 
     @VisibleForTesting
     internal var cameraOpening = false
@@ -37,9 +47,12 @@ internal class Camera2Source(
     fun isOpening() = cameraOpening
 
     fun release() {
+        currentSession?.close()
+        currentSession = null
         cameraDevice?.close()
         cameraDevice = null
         cameraOpening = false
+        currentSurfaces = null
     }
 
     @RequiresPermission(android.Manifest.permission.CAMERA)
@@ -144,6 +157,80 @@ internal class Camera2Source(
         return characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION)
     }
 
+    fun getCameraSensorInfoActiveArraySize(): Rect? {
+        val cameraDevice = this.cameraDevice ?: return null
+        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
+        return characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)
+    }
+
+    /**
+     * Request focus on a particular region
+     *
+     * Sources:
+     * https://gist.github.com/royshil/8c760c2485257c85a11cafd958548482
+     * https://medium.com/androiddevelopers/whats-new-in-camerax-fb8568d6ddc
+     * https://07687375219170485808.googlegroups.com/attach/b86ef247362e5/Touch-to-focus%20API%20Draft.pdf
+     */
+    fun requestFocus(regions: Array<MeteringRectangle>) {
+        // Some safety checks
+        val session = this.currentSession ?: return
+        if (getCameraAvailableAfModes()?.contains(CameraMetadata.CONTROL_AF_MODE_AUTO) != true)
+            return
+        val maxRegionsAf = getCameraAfMaxRegions()
+        if (maxRegionsAf == null || maxRegionsAf < 1) return
+
+        // Stop repeating preview and cancel any existing focus requests
+        session.stopRepeating()
+        val cancelBuilder = createDefaultCaptureRequestBuilder() ?: return
+        cancelBuilder.set(
+            CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL
+        )
+        session.capture(cancelBuilder.build(), null, null)
+
+        // Start new focus request
+        val builder = createDefaultCaptureRequestBuilder(regions = regions) ?: return
+        builder.set(CaptureRequest.CONTROL_AF_MODE, CameraMetadata.CONTROL_AF_MODE_AUTO)
+        builder.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_START)
+        val callback = object : CameraCaptureSession.CaptureCallback() {
+            override fun onCaptureCompleted(
+                session: CameraCaptureSession,
+                request: CaptureRequest,
+                result: TotalCaptureResult
+            ) {
+                createRepeatingRequest(session = session, regions = regions)
+            }
+
+            override fun onCaptureFailed(
+                session: CameraCaptureSession,
+                request: CaptureRequest,
+                failure: CaptureFailure
+            ) {
+                Timber.e("requestAutoFocus() failed: $failure")
+                createRepeatingRequest(session = session)
+            }
+        }
+        session.capture(builder.build(), callback, null)
+    }
+
+    /**
+     * Clear the focus from a particular region
+     */
+    fun clearFocusRegions() {
+        // Some safety checks
+        val session = this.currentSession ?: return
+
+        // Stop repeating preview and cancel any existing focus requests
+        session.stopRepeating()
+        val cancelBuilder = createDefaultCaptureRequestBuilder() ?: return
+        cancelBuilder.set(
+            CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL
+        )
+        session.capture(cancelBuilder.build(), null, null)
+
+        // Restart repeating
+        createRepeatingRequest(session = session)
+    }
+
     @Suppress("ReturnCount") // Better readability
     @VisibleForTesting
     internal fun selectCamera(): String? {
@@ -168,10 +255,10 @@ internal class Camera2Source(
                 surfaces, object : CameraCaptureSession.StateCallback() {
                     override fun onConfigured(session: CameraCaptureSession) {
                         if (cameraDevice == null) return
+                        currentSession = session
+                        currentSurfaces = surfaces
 
-                        createCaptureRequest(
-                            surfaces = surfaces, listener = listener, session = session
-                        )
+                        createRepeatingRequest(session = session, listener = listener)
                     }
 
                     override fun onConfigureFailed(session: CameraCaptureSession) {
@@ -199,37 +286,16 @@ internal class Camera2Source(
     }
 
     @VisibleForTesting
-    internal fun createCaptureRequest(
-        surfaces: List<Surface>,
-        listener: OnCameraReadyListener?,
-        session: CameraCaptureSession
+    internal fun createRepeatingRequest(
+        session: CameraCaptureSession,
+        listener: OnCameraReadyListener? = null,
+        regions: Array<MeteringRectangle>? = null
     ) {
         try {
-            val cameraDevice = this.cameraDevice
-            if (cameraDevice == null) {
-                releaseCameraAndReportException(
-                    listener = listener, message = "Camera device not available.",
-                    cause = NullPointerException()
-                )
-                return
-            }
-            val builder = try {
-                cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
-            } catch (e: IllegalArgumentException) {
-                releaseCameraAndReportException(
-                    listener = listener, message = "TemplateType is not supported by this device.",
-                    cause = e
-                )
-                return
-            }
-            val autoFocus = selectBestAutoFocus()
-            if (autoFocus != null) {
-                builder.set(CaptureRequest.CONTROL_AF_MODE, autoFocus)
-            }
-            builder.set(CaptureRequest.FLASH_MODE, requestedFlashMode)
-            for (surface in surfaces) {
-                builder.addTarget(surface)
-            }
+            val builder = createDefaultCaptureRequestBuilder(listener, regions) ?: return
+            builder.set(CaptureRequest.CONTROL_AF_MODE, selectBestContinuousAfMode())
+            builder.set(CaptureRequest.CONTROL_AE_MODE, selectBestContinuousAeMode())
+            builder.set(CaptureRequest.CONTROL_AWB_MODE, selectBestContinuousAwbMode())
             session.setRepeatingRequest(builder.build(), null, null)
         } catch (e: android.hardware.camera2.CameraAccessException) {
             releaseCameraAndReportException(
@@ -244,6 +310,162 @@ internal class Camera2Source(
                 listener = listener, message = "Surfaces do not meet the requirements", cause = e
             )
         }
+    }
+
+    /**
+     * Select the smallest pixel width size which is still larger than minWidth
+     *
+     * Fall back: Largest size (if none large enough), or just first element
+     */
+    @Suppress("MagicNumber")
+    @VisibleForTesting
+    internal fun chooseOutputSize(sizes: Array<Size>, minWidth: Int): Size {
+        val largeEnoughSizes = sizes.filter { it.width > minWidth }
+        return if (largeEnoughSizes.isNotEmpty()) {
+            largeEnoughSizes.minByOrNull { it.width }
+        } else {
+            sizes.maxByOrNull { it.width }
+        } ?: sizes[0]
+    }
+
+    @VisibleForTesting
+    internal fun createExceptionFromCameraDeviceError(error: Int) = when (error) {
+        CameraDevice.StateCallback.ERROR_CAMERA_IN_USE -> CameraInUseException()
+        CameraDevice.StateCallback.ERROR_MAX_CAMERAS_IN_USE -> MaxCamerasInUseException()
+        CameraDevice.StateCallback.ERROR_CAMERA_DISABLED -> CameraDisabledException()
+        CameraDevice.StateCallback.ERROR_CAMERA_DEVICE -> CameraDeviceException()
+        CameraDevice.StateCallback.ERROR_CAMERA_SERVICE -> CameraServiceException()
+        else -> CameraException()
+    }
+
+    @VisibleForTesting
+    internal fun getCameraAvailableAfModes(): IntArray? {
+        val cameraDevice = this.cameraDevice ?: return null
+        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
+        return characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES)
+    }
+
+    @VisibleForTesting
+    internal fun getCameraAvailableAeModes(): IntArray? {
+        val cameraDevice = this.cameraDevice ?: return null
+        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
+        return characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES)
+    }
+
+    @VisibleForTesting
+    internal fun getCameraAvailableAwbModes(): IntArray? {
+        val cameraDevice = this.cameraDevice ?: return null
+        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
+        return characteristics.get(CameraCharacteristics.CONTROL_AWB_AVAILABLE_MODES)
+    }
+
+    @VisibleForTesting
+    internal fun getCameraAfMaxRegions(): Int? {
+        val cameraDevice = this.cameraDevice ?: return null
+        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
+        return characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF)
+    }
+
+    @VisibleForTesting
+    internal fun getCameraAeMaxRegions(): Int? {
+        val cameraDevice = this.cameraDevice ?: return null
+        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
+        return characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE)
+    }
+
+    @VisibleForTesting
+    internal fun getCameraAwbMaxRegions(): Int? {
+        val cameraDevice = this.cameraDevice ?: return null
+        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
+        return characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AWB)
+    }
+
+    @VisibleForTesting
+    internal fun selectBestContinuousAfMode(): Int {
+        val available = getCameraAvailableAfModes() ?: return CameraMetadata.CONTROL_AF_MODE_OFF
+        return when {
+            available.contains(CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE) ->
+                CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE
+            available.contains(CameraMetadata.CONTROL_AF_MODE_AUTO) ->
+                CameraMetadata.CONTROL_AF_MODE_AUTO
+            else ->
+                CameraMetadata.CONTROL_AF_MODE_OFF
+        }
+    }
+
+    @VisibleForTesting
+    internal fun selectBestContinuousAeMode(): Int {
+        val available = getCameraAvailableAeModes() ?: return CameraMetadata.CONTROL_AE_MODE_OFF
+        return when {
+            available.contains(CameraMetadata.CONTROL_AE_MODE_ON) ->
+                CameraMetadata.CONTROL_AE_MODE_ON
+            else ->
+                CameraMetadata.CONTROL_AE_MODE_OFF
+        }
+    }
+
+    @VisibleForTesting
+    internal fun selectBestContinuousAwbMode(): Int {
+        val available = getCameraAvailableAwbModes() ?: return CameraMetadata.CONTROL_AWB_MODE_OFF
+        return when {
+            available.contains(CameraMetadata.CONTROL_AWB_MODE_AUTO) ->
+                CameraMetadata.CONTROL_AWB_MODE_AUTO
+            else ->
+                CameraMetadata.CONTROL_AWB_MODE_OFF
+        }
+    }
+
+    @VisibleForTesting
+    internal fun createDefaultCaptureRequestBuilder(
+        listener: OnCameraReadyListener? = null,
+        regions: Array<MeteringRectangle>? = null
+    ): CaptureRequest.Builder? {
+        val cameraDevice = this.cameraDevice
+        if (cameraDevice == null) {
+            releaseCameraAndReportException(
+                listener = listener, message = "Camera device not available.",
+                cause = NullPointerException()
+            )
+            return null
+        }
+        val surfaces = this.currentSurfaces
+        if (surfaces == null) {
+            releaseCameraAndReportException(
+                listener = listener, message = "Surfaces not available.",
+                cause = NullPointerException()
+            )
+            return null
+        }
+        val builder = try {
+            cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
+        } catch (e: IllegalArgumentException) {
+            releaseCameraAndReportException(
+                listener = listener, message = "TemplateType is not supported by this device.",
+                cause = e
+            )
+            return null
+        }
+        builder.set(CaptureRequest.FLASH_MODE, requestedFlashMode)
+
+        if (regions != null) {
+            val maxRegionsAf = getCameraAfMaxRegions()
+            if (maxRegionsAf != null && maxRegionsAf > 0) {
+                builder.set(CaptureRequest.CONTROL_AF_REGIONS, regions)
+            }
+            val maxRegionsAe = getCameraAeMaxRegions()
+            if (maxRegionsAe != null && maxRegionsAe > 0) {
+                builder.set(CaptureRequest.CONTROL_AE_REGIONS, regions)
+            }
+            val maxRegionsAwb = getCameraAwbMaxRegions()
+            if (maxRegionsAwb != null && maxRegionsAwb > 0) {
+                builder.set(CaptureRequest.CONTROL_AWB_REGIONS, regions)
+            }
+        }
+
+        for (surface in surfaces) {
+            builder.addTarget(surface)
+        }
+        return builder
     }
 
     private fun releaseCameraAndReportException(
@@ -272,49 +494,6 @@ internal class Camera2Source(
         release()
         Timber.e(exception, message)
         listener?.onCameraFailure(exception)
-    }
-
-    /**
-     * Select the smallest pixel width size which is still larger than minWidth
-     *
-     * Fall back: Largest size (if none large enough), or just first element
-     */
-    @Suppress("MagicNumber")
-    @VisibleForTesting
-    internal fun chooseOutputSize(sizes: Array<Size>, minWidth: Int): Size {
-        val largeEnoughSizes = sizes.filter { it.width > minWidth }
-        return if (largeEnoughSizes.isNotEmpty()) {
-            largeEnoughSizes.minBy { it.width }
-        } else {
-            sizes.maxBy { it.width }
-        } ?: sizes[0]
-    }
-
-    @VisibleForTesting
-    internal fun createExceptionFromCameraDeviceError(error: Int) = when (error) {
-        CameraDevice.StateCallback.ERROR_CAMERA_IN_USE -> CameraInUseException()
-        CameraDevice.StateCallback.ERROR_MAX_CAMERAS_IN_USE -> MaxCamerasInUseException()
-        CameraDevice.StateCallback.ERROR_CAMERA_DISABLED -> CameraDisabledException()
-        CameraDevice.StateCallback.ERROR_CAMERA_DEVICE -> CameraDeviceException()
-        CameraDevice.StateCallback.ERROR_CAMERA_SERVICE -> CameraServiceException()
-        else -> CameraException()
-    }
-
-    @Suppress("ReturnCount") // For readability
-    @VisibleForTesting
-    internal fun selectBestAutoFocus(): Int? {
-        val cameraDevice = this.cameraDevice ?: return null
-        val characteristics = cameraManager.getCameraCharacteristics(cameraDevice.id)
-        val available = characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES)
-            ?: throw IllegalStateException() // This key is available on all devices
-        return when {
-            available.contains(CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE) ->
-                CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE
-            available.contains(CameraMetadata.CONTROL_AF_MODE_AUTO) ->
-                CameraMetadata.CONTROL_AF_MODE_AUTO
-            else ->
-                CameraMetadata.CONTROL_AF_MODE_OFF
-        }
     }
 
     companion object {

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/Camera2Source.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/camera/Camera2Source.kt
@@ -174,8 +174,9 @@ internal class Camera2Source(
     fun requestFocus(regions: Array<MeteringRectangle>) {
         // Some safety checks
         val session = this.currentSession ?: return
-        if (getCameraAvailableAfModes()?.contains(CameraMetadata.CONTROL_AF_MODE_AUTO) != true)
+        if (getCameraAvailableAfModes()?.contains(CameraMetadata.CONTROL_AF_MODE_AUTO) != true) {
             return
+        }
         val maxRegionsAf = getCameraAfMaxRegions()
         if (maxRegionsAf == null || maxRegionsAf < 1) return
 

--- a/kbarcode/src/main/res/values/attrs.xml
+++ b/kbarcode/src/main/res/values/attrs.xml
@@ -31,5 +31,8 @@
             <enum name="centerInside" value="0" />
             <enum name="centerCrop" value="1" />
         </attr>
+        <attr name="clearFocusDelay" format="enum|integer">
+            <enum name="never" value="-1" />
+        </attr>
     </declare-styleable>
 </resources>

--- a/kbarcode/src/test/java/uk/co/brightec/kbarcode/KBarcodeScannerTest.kt
+++ b/kbarcode/src/test/java/uk/co/brightec/kbarcode/KBarcodeScannerTest.kt
@@ -2,12 +2,12 @@ package uk.co.brightec.kbarcode
 
 import androidx.lifecycle.LiveData
 import androidx.test.filters.SmallTest
+import org.junit.Before
+import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
-import org.junit.Before
-import org.junit.Test
 import uk.co.brightec.kbarcode.camera.OnCameraErrorListener
 import uk.co.brightec.kbarcode.processor.OnBarcodeListener
 import uk.co.brightec.kbarcode.processor.OnBarcodesListener
@@ -32,6 +32,7 @@ internal class KBarcodeScannerTest {
             on { minBarcodeWidth } doReturn -2
             on { barcodesSort } doReturn mock()
             on { scaleType } doReturn -3
+            on { clearFocusDelay } doReturn 1234L
         }
 
         // WHEN
@@ -44,6 +45,7 @@ internal class KBarcodeScannerTest {
         verify(barcodeScanner).setMinBarcodeWidth(options.minBarcodeWidth)
         verify(barcodeScanner).setBarcodesSort(options.barcodesSort)
         verify(barcodeScanner).setScaleType(options.scaleType)
+        verify(barcodeScanner).setClearFocusDelay(options.clearFocusDelay)
     }
 
     private class BarcodeScanner : KBarcode.Scanner {
@@ -93,6 +95,10 @@ internal class KBarcodeScannerTest {
         }
 
         override fun setScaleType(scaleType: Int) {
+            // no-op
+        }
+
+        override fun setClearFocusDelay(delay: Long) {
             // no-op
         }
     }

--- a/kbarcode/src/test/java/uk/co/brightec/kbarcode/camera/Camera2SourceTest.kt
+++ b/kbarcode/src/test/java/uk/co/brightec/kbarcode/camera/Camera2SourceTest.kt
@@ -35,6 +35,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyZeroInteractions
 import org.mockito.kotlin.whenever
 
+@Suppress("LargeClass")
 @SmallTest
 internal class Camera2SourceTest {
 
@@ -1184,7 +1185,7 @@ internal class Camera2SourceTest {
     }
 
     @Test
-    fun cameraDevice_captureIllegalArgExc__createDefaultCaptureRequestBuilder__release_callsListener() {
+    fun cameraDevice_captureIllegalArgExc__createDefaultCaptureRequestBuilder__release_listener() {
         // GIVEN
         cameraSource.cameraDevice = cameraDevice
         whenever(cameraDevice.createCaptureRequest(any()))

--- a/kbarcode/src/test/java/uk/co/brightec/kbarcode/camera/Camera2SourceTest.kt
+++ b/kbarcode/src/test/java/uk/co/brightec/kbarcode/camera/Camera2SourceTest.kt
@@ -1,11 +1,13 @@
 package uk.co.brightec.kbarcode.camera
 
+import android.graphics.Rect
 import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.params.MeteringRectangle
 import android.hardware.camera2.params.StreamConfigurationMap
 import android.os.Handler
 import android.util.Size
@@ -13,6 +15,7 @@ import android.view.Surface
 import androidx.test.filters.SmallTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -27,7 +30,9 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyZeroInteractions
 import org.mockito.kotlin.whenever
 
 @SmallTest
@@ -35,6 +40,7 @@ internal class Camera2SourceTest {
 
     private lateinit var cameraManager: CameraManager
     private lateinit var cameraDevice: CameraDevice
+    private lateinit var session: CameraCaptureSession
 
     private lateinit var cameraSource: Camera2Source
 
@@ -44,6 +50,7 @@ internal class Camera2SourceTest {
         cameraDevice = mock {
             on { id } doReturn "some id"
         }
+        session = mock()
 
         cameraSource = spy(Camera2Source(cameraManager))
     }
@@ -100,14 +107,19 @@ internal class Camera2SourceTest {
     fun cameraDevice__release__closesCameraDevice() {
         // GIVEN
         cameraSource.cameraDevice = cameraDevice
+        cameraSource.currentSession = session
+        cameraSource.currentSurfaces = mock()
 
         // WHEN
         cameraSource.release()
 
         // THEN
+        verify(session).close()
+        assertNull(cameraSource.currentSession)
         verify(cameraDevice).close()
         assertNull(cameraSource.cameraDevice)
         assertFalse(cameraSource.cameraOpening)
+        assertNull(cameraSource.currentSurfaces)
     }
 
     @Test
@@ -319,6 +331,198 @@ internal class Camera2SourceTest {
     }
 
     @Test
+    fun characteristics__getCameraSensorInfoActiveArraySize__isCorrect() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val rect = mock<Rect>()
+        val characteristics = mock<CameraCharacteristics> {
+            on { get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE) } doReturn rect
+        }
+        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
+            .thenReturn(characteristics)
+
+        // WHEN
+        val result = cameraSource.getCameraSensorInfoActiveArraySize()
+
+        // THEN
+        assertEquals(rect, result)
+    }
+
+    @Test
+    fun session_noAf__requestFocus__nothing() {
+        // GIVEN
+        val session = mock<CameraCaptureSession>()
+        cameraSource.currentSession = session
+        val afModes = intArrayOf()
+        doReturn(afModes).whenever(cameraSource).getCameraAvailableAfModes()
+
+        // WHEN
+        val regions = arrayOf(mock<MeteringRectangle>())
+        cameraSource.requestFocus(regions)
+
+        // THEN
+        verifyZeroInteractions(session)
+    }
+
+    @Test
+    fun session_noAfRegions__requestFocus__nothing() {
+        // GIVEN
+        val session = mock<CameraCaptureSession>()
+        cameraSource.currentSession = session
+        val afModes = intArrayOf(CameraMetadata.CONTROL_AF_MODE_AUTO)
+        doReturn(afModes).whenever(cameraSource).getCameraAvailableAfModes()
+        doReturn(0).whenever(cameraSource).getCameraAfMaxRegions()
+
+        // WHEN
+        val regions = arrayOf(mock<MeteringRectangle>())
+        cameraSource.requestFocus(regions)
+
+        // THEN
+        verifyZeroInteractions(session)
+    }
+
+    @Test
+    fun session_af__requestFocus__stopRepeating_cancelAf_startAf() {
+        // GIVEN
+        val session = mock<CameraCaptureSession>()
+        cameraSource.currentSession = session
+        val cancelRequest = mock<CaptureRequest>()
+        val cancelRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn cancelRequest
+        }
+        val startRequest = mock<CaptureRequest>()
+        val startRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn startRequest
+        }
+        doReturn(cancelRequestBuilder).doReturn(startRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+        val afModes = intArrayOf(CameraMetadata.CONTROL_AF_MODE_AUTO)
+        doReturn(afModes).whenever(cameraSource).getCameraAvailableAfModes()
+        doReturn(1).whenever(cameraSource).getCameraAfMaxRegions()
+
+        // WHEN
+        val regions = arrayOf(mock<MeteringRectangle>())
+        cameraSource.requestFocus(regions)
+
+        // THEN
+        verify(session).stopRepeating()
+        verify(cameraSource).createDefaultCaptureRequestBuilder(null, null)
+        verify(session, times(2)).capture(any(), anyOrNull(), anyOrNull())
+        verify(cancelRequestBuilder)
+            .set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL)
+        verify(cameraSource).createDefaultCaptureRequestBuilder(null, regions)
+        // Unable to verify the specifics due to mockito limitations
+        // So have to settle for this
+        verify(startRequestBuilder, times(2))
+            .set(anyOrNull<CaptureRequest.Key<Int>>(), eq(1))
+    }
+
+    @Test
+    fun session_af_completeAf__requestFocus__restartRepeatingWithRegions() {
+        // STUB
+        doNothing().whenever(cameraSource).createRepeatingRequest(any(), anyOrNull(), anyOrNull())
+
+        // GIVEN
+        val session = mock<CameraCaptureSession>()
+        cameraSource.currentSession = session
+        val cancelRequest = mock<CaptureRequest>()
+        val cancelRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn cancelRequest
+        }
+        val startRequest = mock<CaptureRequest>()
+        val startRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn startRequest
+        }
+        doReturn(cancelRequestBuilder).doReturn(startRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+        val afModes = intArrayOf(CameraMetadata.CONTROL_AF_MODE_AUTO)
+        doReturn(afModes).whenever(cameraSource).getCameraAvailableAfModes()
+        doReturn(1).whenever(cameraSource).getCameraAfMaxRegions()
+        whenever(session.capture(any(), anyOrNull(), anyOrNull())).thenAnswer {
+            val request = it.getArgument<CaptureRequest>(0)
+            val callback = it.getArgument<CameraCaptureSession.CaptureCallback?>(1)
+            callback?.onCaptureCompleted(session, request, mock())
+            1234
+        }
+
+        // WHEN
+        val regions = arrayOf(mock<MeteringRectangle>())
+        cameraSource.requestFocus(regions)
+
+        // THEN
+        verify(cameraSource).createRepeatingRequest(
+            session = session, listener = null, regions = regions
+        )
+    }
+
+    @Test
+    fun session_af_failedAf__requestFocus__restartRepeatingWithRegions() {
+        // STUB
+        doNothing().whenever(cameraSource).createRepeatingRequest(any(), anyOrNull(), anyOrNull())
+
+        // GIVEN
+        val session = mock<CameraCaptureSession>()
+        cameraSource.currentSession = session
+        val cancelRequest = mock<CaptureRequest>()
+        val cancelRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn cancelRequest
+        }
+        val startRequest = mock<CaptureRequest>()
+        val startRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn startRequest
+        }
+        doReturn(cancelRequestBuilder).doReturn(startRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+        val afModes = intArrayOf(CameraMetadata.CONTROL_AF_MODE_AUTO)
+        doReturn(afModes).whenever(cameraSource).getCameraAvailableAfModes()
+        doReturn(1).whenever(cameraSource).getCameraAfMaxRegions()
+        whenever(session.capture(any(), anyOrNull(), anyOrNull())).thenAnswer {
+            val request = it.getArgument<CaptureRequest>(0)
+            val callback = it.getArgument<CameraCaptureSession.CaptureCallback?>(1)
+            callback?.onCaptureFailed(session, request, mock())
+            1234
+        }
+
+        // WHEN
+        val regions = arrayOf(mock<MeteringRectangle>())
+        cameraSource.requestFocus(regions)
+
+        // THEN
+        verify(cameraSource).createRepeatingRequest(
+            session = session, listener = null, regions = null
+        )
+    }
+
+    @Test
+    fun session_af__clearFocusRegions__stopRepeating_cancelAf_restartRepeating() {
+        // STUB
+        doNothing().whenever(cameraSource).createRepeatingRequest(any(), anyOrNull(), anyOrNull())
+
+        // GIVEN
+        val session = mock<CameraCaptureSession>()
+        cameraSource.currentSession = session
+        val cancelRequest = mock<CaptureRequest>()
+        val cancelRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn cancelRequest
+        }
+        doReturn(cancelRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+
+        // WHEN
+        cameraSource.clearFocusRegions()
+
+        // THEN
+        verify(session).stopRepeating()
+        verify(cameraSource).createDefaultCaptureRequestBuilder(null, null)
+        verify(session).capture(any(), anyOrNull(), anyOrNull())
+        verify(cancelRequestBuilder)
+            .set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL)
+        verify(cameraSource).createRepeatingRequest(
+            session = session, listener = null, regions = null
+        )
+    }
+
+    @Test
     fun listInclFacing__selectCamera__isCorrect() {
         // GIVEN
         val cameraId1 = "1"
@@ -384,13 +588,12 @@ internal class Camera2SourceTest {
     }
 
     @Test
-    fun cameraDevice_configured__createCaptureSession__createCaptureRequest() {
+    fun cameraDevice_configured__createCaptureSession__createRepeatingRequest() {
         // STUB
-        doNothing().whenever(cameraSource).createCaptureRequest(any(), anyOrNull(), any())
+        doNothing().whenever(cameraSource).createRepeatingRequest(any(), anyOrNull(), anyOrNull())
 
         // GIVEN
         cameraSource.cameraDevice = cameraDevice
-        val session = mock<CameraCaptureSession>()
         whenever(cameraDevice.createCaptureSession(any(), any(), anyOrNull())).then {
             val stateCallback = it.getArgument<CameraCaptureSession.StateCallback>(1)
             stateCallback.onConfigured(session)
@@ -402,7 +605,11 @@ internal class Camera2SourceTest {
         cameraSource.createCaptureSession(surfaces, listener)
 
         // THEN
-        verify(cameraSource).createCaptureRequest(surfaces, listener, session)
+        verify(cameraSource).currentSession = session
+        verify(cameraSource).currentSurfaces = surfaces
+        verify(cameraSource).createRepeatingRequest(
+            session = session, listener = listener, regions = null
+        )
     }
 
     @Test
@@ -477,100 +684,37 @@ internal class Camera2SourceTest {
     }
 
     @Test
-    fun cameraDevice_session_autoFocus_flashMode__createCaptureRequest__setsRepeatingRequest() {
+    fun session_modes__createRepeatingRequest__setsRepeatingRequest() {
         // GIVEN
-        cameraSource.cameraDevice = cameraDevice
         val session = mock<CameraCaptureSession>()
         val captureRequest = mock<CaptureRequest>()
         val captureRequestBuilder = mock<CaptureRequest.Builder> {
             on { build() } doReturn captureRequest
         }
-        whenever(cameraDevice.createCaptureRequest(any())).thenReturn(captureRequestBuilder)
-        val autoFocus = 1
-        doReturn(autoFocus).whenever(cameraSource).selectBestAutoFocus()
-        val flashMode = -1
-        cameraSource.requestedFlashMode = flashMode
+        doReturn(captureRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+        val afMode = 123
+        doReturn(afMode).whenever(cameraSource).selectBestContinuousAfMode()
+        val aeMode = 456
+        doReturn(aeMode).whenever(cameraSource).selectBestContinuousAeMode()
+        val awbMode = 789
+        doReturn(awbMode).whenever(cameraSource).selectBestContinuousAwbMode()
 
         // WHEN
-        val surfaces = listOf<Surface>(mock(), mock())
-        cameraSource.createCaptureRequest(
-            surfaces = surfaces, listener = mock(), session = session
+        cameraSource.createRepeatingRequest(
+            session = session, listener = mock(), regions = arrayOf(mock())
         )
 
         // THEN
-        verify(captureRequestBuilder).set(CaptureRequest.CONTROL_AF_MODE, autoFocus)
-        verify(captureRequestBuilder).set(CaptureRequest.FLASH_MODE, flashMode)
-        verify(captureRequestBuilder).addTarget(surfaces[0])
-        verify(captureRequestBuilder).addTarget(surfaces[1])
+        verify(captureRequestBuilder).set(CaptureRequest.CONTROL_AF_MODE, afMode)
+        verify(captureRequestBuilder).set(CaptureRequest.CONTROL_AE_MODE, aeMode)
+        verify(captureRequestBuilder).set(CaptureRequest.CONTROL_AWB_MODE, awbMode)
         verify(session).setRepeatingRequest(captureRequest, null, null)
     }
 
     @Test
-    fun cameraDevice_session_captureIllegalArgExc__createCaptureRequest__release_callsListener() {
+    fun session_modes_requestCameraAccessExc__createRepeatingRequest__release_callsListener() {
         // GIVEN
-        cameraSource.cameraDevice = cameraDevice
-        val session = mock<CameraCaptureSession>()
-        whenever(cameraDevice.createCaptureRequest(any()))
-            .doThrow(mock<IllegalArgumentException>())
-
-        // WHEN
-        val surfaces = listOf<Surface>(mock(), mock())
-        val listener = mock<OnCameraReadyListener>()
-        cameraSource.createCaptureRequest(
-            surfaces = surfaces, listener = listener, session = session
-        )
-
-        // THEN
-        verify(cameraSource).release()
-        verify(listener).onCameraFailure(any())
-    }
-
-    @Test
-    fun cameraDevice_session_captureCameraAccessExc__createCaptureRequest__release_callsListener() {
-        // GIVEN
-        cameraSource.cameraDevice = cameraDevice
-        val session = mock<CameraCaptureSession>()
-        whenever(cameraDevice.createCaptureRequest(any()))
-            .doThrow(mock<android.hardware.camera2.CameraAccessException>())
-
-        // WHEN
-        val surfaces = listOf<Surface>(mock(), mock())
-        val listener = mock<OnCameraReadyListener>()
-        cameraSource.createCaptureRequest(
-            surfaces = surfaces, listener = listener, session = session
-        )
-
-        // THEN
-        verify(cameraSource).release()
-        verify(listener).onCameraFailure(any<CameraAccessException>())
-    }
-
-    @Test
-    fun cameraDevice_session_captureIllegalStateExc__createCaptureRequest__release_callsListener() {
-        // GIVEN
-        cameraSource.cameraDevice = cameraDevice
-        val session = mock<CameraCaptureSession>()
-        whenever(cameraDevice.createCaptureRequest(any()))
-            .doThrow(mock<IllegalStateException>())
-
-        // WHEN
-        val surfaces = listOf<Surface>(mock(), mock())
-        val listener = mock<OnCameraReadyListener>()
-        cameraSource.createCaptureRequest(
-            surfaces = surfaces, listener = listener, session = session
-        )
-
-        // THEN
-        verify(cameraSource).release()
-        verify(listener).onCameraFailure(any())
-    }
-
-    @Test
-    fun cameraDevice_session_requestCameraAccessExc__createCaptureRequest__release_callsListener() {
-        // GIVEN
-        cameraSource.cameraDevice = cameraDevice
-        val autoFocus = 1
-        doReturn(autoFocus).whenever(cameraSource).selectBestAutoFocus()
         val session = mock<CameraCaptureSession> {
             on {
                 setRepeatingRequest(any(), anyOrNull(), anyOrNull())
@@ -580,14 +724,15 @@ internal class Camera2SourceTest {
         val captureRequestBuilder = mock<CaptureRequest.Builder> {
             on { build() } doReturn captureRequest
         }
-        whenever(cameraDevice.createCaptureRequest(any())).thenReturn(captureRequestBuilder)
+        doReturn(captureRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+        doReturn(123).whenever(cameraSource).selectBestContinuousAfMode()
+        doReturn(456).whenever(cameraSource).selectBestContinuousAeMode()
+        doReturn(789).whenever(cameraSource).selectBestContinuousAwbMode()
 
         // WHEN
-        val surfaces = listOf<Surface>(mock(), mock())
         val listener = mock<OnCameraReadyListener>()
-        cameraSource.createCaptureRequest(
-            surfaces = surfaces, listener = listener, session = session
-        )
+        cameraSource.createRepeatingRequest(session = session, listener = listener)
 
         // THEN
         verify(cameraSource).release()
@@ -595,11 +740,9 @@ internal class Camera2SourceTest {
     }
 
     @Test
-    fun cameraDevice_session_requestIllegalArgExc__createCaptureRequest__release_callsListener() {
+    fun session_modes_requestIllegalArgExc__createRepeatingRequest__release_callsListener() {
         // GIVEN
         cameraSource.cameraDevice = cameraDevice
-        val autoFocus = 1
-        doReturn(autoFocus).whenever(cameraSource).selectBestAutoFocus()
         val session = mock<CameraCaptureSession> {
             on {
                 setRepeatingRequest(any(), anyOrNull(), anyOrNull())
@@ -609,14 +752,15 @@ internal class Camera2SourceTest {
         val captureRequestBuilder = mock<CaptureRequest.Builder> {
             on { build() } doReturn captureRequest
         }
-        whenever(cameraDevice.createCaptureRequest(any())).thenReturn(captureRequestBuilder)
+        doReturn(captureRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+        doReturn(123).whenever(cameraSource).selectBestContinuousAfMode()
+        doReturn(456).whenever(cameraSource).selectBestContinuousAeMode()
+        doReturn(789).whenever(cameraSource).selectBestContinuousAwbMode()
 
         // WHEN
-        val surfaces = listOf<Surface>(mock(), mock())
         val listener = mock<OnCameraReadyListener>()
-        cameraSource.createCaptureRequest(
-            surfaces = surfaces, listener = listener, session = session
-        )
+        cameraSource.createRepeatingRequest(session = session, listener = listener)
 
         // THEN
         verify(cameraSource).release()
@@ -624,11 +768,9 @@ internal class Camera2SourceTest {
     }
 
     @Test
-    fun cameraDevice_session_requestIllegalStateExc__createCaptureRequest__release_callsListener() {
+    fun session_modes_requestIllegalStateExc__createRepeatingRequest__release_callsListener() {
         // GIVEN
         cameraSource.cameraDevice = cameraDevice
-        val autoFocus = 1
-        doReturn(autoFocus).whenever(cameraSource).selectBestAutoFocus()
         val session = mock<CameraCaptureSession> {
             on {
                 setRepeatingRequest(any(), anyOrNull(), anyOrNull())
@@ -638,14 +780,15 @@ internal class Camera2SourceTest {
         val captureRequestBuilder = mock<CaptureRequest.Builder> {
             on { build() } doReturn captureRequest
         }
-        whenever(cameraDevice.createCaptureRequest(any())).thenReturn(captureRequestBuilder)
+        doReturn(captureRequestBuilder).whenever(cameraSource)
+            .createDefaultCaptureRequestBuilder(anyOrNull(), anyOrNull())
+        doReturn(123).whenever(cameraSource).selectBestContinuousAfMode()
+        doReturn(456).whenever(cameraSource).selectBestContinuousAeMode()
+        doReturn(789).whenever(cameraSource).selectBestContinuousAwbMode()
 
         // WHEN
-        val surfaces = listOf<Surface>(mock(), mock())
         val listener = mock<OnCameraReadyListener>()
-        cameraSource.createCaptureRequest(
-            surfaces = surfaces, listener = listener, session = session
-        )
+        cameraSource.createRepeatingRequest(session = session, listener = listener)
 
         // THEN
         verify(cameraSource).release()
@@ -776,60 +919,283 @@ internal class Camera2SourceTest {
     }
 
     @Test
-    fun continuousAvailable__selectBestAutoFocus__continuous() {
+    fun characteristics__getCameraAvailableAfModes__isCorrect() {
         // GIVEN
         cameraSource.cameraDevice = cameraDevice
-        val available = IntArray(1).apply {
-            this[0] = CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE
-        }
+        val modes = intArrayOf(1, 2, 3)
         val characteristics = mock<CameraCharacteristics> {
-            on { get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES) } doReturn available
+            on { get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES) } doReturn modes
         }
         whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
             .thenReturn(characteristics)
 
         // WHEN
-        val result = cameraSource.selectBestAutoFocus()
+        val result = cameraSource.getCameraAvailableAfModes()
+
+        // THEN
+        assertEquals(modes, result)
+    }
+
+    @Test
+    fun characteristics__getCameraAvailableAeModes__isCorrect() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val modes = intArrayOf(1, 2, 3)
+        val characteristics = mock<CameraCharacteristics> {
+            on { get(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES) } doReturn modes
+        }
+        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
+            .thenReturn(characteristics)
+
+        // WHEN
+        val result = cameraSource.getCameraAvailableAeModes()
+
+        // THEN
+        assertEquals(modes, result)
+    }
+
+    @Test
+    fun characteristics__getCameraAvailableAwbModes__isCorrect() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val modes = intArrayOf(1, 2, 3)
+        val characteristics = mock<CameraCharacteristics> {
+            on { get(CameraCharacteristics.CONTROL_AWB_AVAILABLE_MODES) } doReturn modes
+        }
+        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
+            .thenReturn(characteristics)
+
+        // WHEN
+        val result = cameraSource.getCameraAvailableAwbModes()
+
+        // THEN
+        assertEquals(modes, result)
+    }
+
+    @Test
+    fun characteristics__getCameraAfMaxRegions__isCorrect() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val maxRegions = 123
+        val characteristics = mock<CameraCharacteristics> {
+            on { get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF) } doReturn maxRegions
+        }
+        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
+            .thenReturn(characteristics)
+
+        // WHEN
+        val result = cameraSource.getCameraAfMaxRegions()
+
+        // THEN
+        assertEquals(maxRegions, result)
+    }
+
+    @Test
+    fun characteristics__getCameraAeMaxRegions__isCorrect() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val maxRegions = 123
+        val characteristics = mock<CameraCharacteristics> {
+            on { get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE) } doReturn maxRegions
+        }
+        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
+            .thenReturn(characteristics)
+
+        // WHEN
+        val result = cameraSource.getCameraAeMaxRegions()
+
+        // THEN
+        assertEquals(maxRegions, result)
+    }
+
+    @Test
+    fun characteristics__getCameraAwbMaxRegions__isCorrect() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val maxRegions = 123
+        val characteristics = mock<CameraCharacteristics> {
+            on { get(CameraCharacteristics.CONTROL_MAX_REGIONS_AWB) } doReturn maxRegions
+        }
+        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
+            .thenReturn(characteristics)
+
+        // WHEN
+        val result = cameraSource.getCameraAwbMaxRegions()
+
+        // THEN
+        assertEquals(maxRegions, result)
+    }
+
+    @Test
+    fun continuousAvailable__selectBestContinuousAfMode__continuous() {
+        // GIVEN
+        val available = intArrayOf(
+            CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE, CameraMetadata.CONTROL_AF_MODE_AUTO
+        )
+        doReturn(available).whenever(cameraSource).getCameraAvailableAfModes()
+
+        // WHEN
+        val result = cameraSource.selectBestContinuousAfMode()
 
         // THEN
         assertEquals(CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE, result)
     }
 
     @Test
-    fun autoAvailable__selectBestAutoFocus__auto() {
+    fun autoAvailable__selectBestContinuousAfMode__auto() {
         // GIVEN
-        cameraSource.cameraDevice = cameraDevice
-        val available = IntArray(1).apply {
-            this[0] = CameraMetadata.CONTROL_AF_MODE_AUTO
-        }
-        val characteristics = mock<CameraCharacteristics> {
-            on { get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES) } doReturn available
-        }
-        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
-            .thenReturn(characteristics)
+        val available = intArrayOf(
+            CameraMetadata.CONTROL_AF_MODE_AUTO
+        )
+        doReturn(available).whenever(cameraSource).getCameraAvailableAfModes()
 
         // WHEN
-        val result = cameraSource.selectBestAutoFocus()
+        val result = cameraSource.selectBestContinuousAfMode()
 
         // THEN
         assertEquals(CameraMetadata.CONTROL_AF_MODE_AUTO, result)
     }
 
     @Test
-    fun available__selectBestAutoFocus__off() {
+    fun available__selectBestContinuousAfMode__off() {
         // GIVEN
-        cameraSource.cameraDevice = cameraDevice
-        val available = IntArray(1)
-        val characteristics = mock<CameraCharacteristics> {
-            on { get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES) } doReturn available
-        }
-        whenever(cameraManager.getCameraCharacteristics(cameraDevice.id))
-            .thenReturn(characteristics)
+        val available = intArrayOf()
+        doReturn(available).whenever(cameraSource).getCameraAvailableAfModes()
 
         // WHEN
-        val result = cameraSource.selectBestAutoFocus()
+        val result = cameraSource.selectBestContinuousAfMode()
 
         // THEN
         assertEquals(CameraMetadata.CONTROL_AF_MODE_OFF, result)
+    }
+
+    @Test
+    fun onAvailable__selectBestContinuousAeMode__on() {
+        // GIVEN
+        val available = intArrayOf(
+            CameraMetadata.CONTROL_AE_MODE_ON, CameraMetadata.CONTROL_AE_MODE_OFF
+        )
+        doReturn(available).whenever(cameraSource).getCameraAvailableAeModes()
+
+        // WHEN
+        val result = cameraSource.selectBestContinuousAeMode()
+
+        // THEN
+        assertEquals(CameraMetadata.CONTROL_AE_MODE_ON, result)
+    }
+
+    @Test
+    fun available__selectBestContinuousAeMode__off() {
+        // GIVEN
+        val available = intArrayOf()
+        doReturn(available).whenever(cameraSource).getCameraAvailableAeModes()
+
+        // WHEN
+        val result = cameraSource.selectBestContinuousAeMode()
+
+        // THEN
+        assertEquals(CameraMetadata.CONTROL_AE_MODE_OFF, result)
+    }
+
+    @Test
+    fun onAvailable__selectBestContinuousAwbMode__auto() {
+        // GIVEN
+        val available = intArrayOf(
+            CameraMetadata.CONTROL_AWB_MODE_AUTO, CameraMetadata.CONTROL_AWB_MODE_OFF
+        )
+        doReturn(available).whenever(cameraSource).getCameraAvailableAwbModes()
+
+        // WHEN
+        val result = cameraSource.selectBestContinuousAwbMode()
+
+        // THEN
+        assertEquals(CameraMetadata.CONTROL_AWB_MODE_AUTO, result)
+    }
+
+    @Test
+    fun available__selectBestContinuousAwbMode__off() {
+        // GIVEN
+        val available = intArrayOf()
+        doReturn(available).whenever(cameraSource).getCameraAvailableAwbModes()
+
+        // WHEN
+        val result = cameraSource.selectBestContinuousAwbMode()
+
+        // THEN
+        assertEquals(CameraMetadata.CONTROL_AWB_MODE_OFF, result)
+    }
+
+    @Test
+    fun cameraDevice_surfaces_flashMode__createDefaultCaptureRequestBuilder__asExpected() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val surfaces = listOf<Surface>(mock(), mock())
+        cameraSource.currentSurfaces = surfaces
+        val captureRequest = mock<CaptureRequest>()
+        val captureRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn captureRequest
+        }
+        whenever(cameraDevice.createCaptureRequest(any())).thenReturn(captureRequestBuilder)
+        val flashMode = -1
+        cameraSource.requestedFlashMode = flashMode
+
+        // WHEN
+        val result = cameraSource.createDefaultCaptureRequestBuilder(
+            listener = mock(), regions = null
+        )
+
+        // THEN
+        assertNotNull(result)
+        verify(captureRequestBuilder).set(CaptureRequest.FLASH_MODE, flashMode)
+        verify(captureRequestBuilder).addTarget(surfaces[0])
+        verify(captureRequestBuilder).addTarget(surfaces[1])
+    }
+
+    @Test
+    fun cameraDevice_surfaces_flashMode_regions__createDefaultCaptureRequestBuilder__asExpected() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        val surfaces = listOf<Surface>(mock(), mock())
+        cameraSource.currentSurfaces = surfaces
+        val captureRequest = mock<CaptureRequest>()
+        val captureRequestBuilder = mock<CaptureRequest.Builder> {
+            on { build() } doReturn captureRequest
+        }
+        whenever(cameraDevice.createCaptureRequest(any())).thenReturn(captureRequestBuilder)
+        val flashMode = -1
+        cameraSource.requestedFlashMode = flashMode
+        val regions = arrayOf(mock<MeteringRectangle>())
+        doReturn(1).whenever(cameraSource).getCameraAfMaxRegions()
+        doReturn(1).whenever(cameraSource).getCameraAeMaxRegions()
+        doReturn(1).whenever(cameraSource).getCameraAwbMaxRegions()
+
+        // WHEN
+        val result = cameraSource.createDefaultCaptureRequestBuilder(
+            listener = mock(), regions = regions
+        )
+
+        // THEN
+        assertNotNull(result)
+        verify(captureRequestBuilder).set(CaptureRequest.FLASH_MODE, flashMode)
+        verify(captureRequestBuilder, times(3))
+            .set(anyOrNull<CaptureRequest.Key<Array<MeteringRectangle>>>(), eq(regions))
+        verify(captureRequestBuilder).addTarget(surfaces[0])
+        verify(captureRequestBuilder).addTarget(surfaces[1])
+    }
+
+    @Test
+    fun cameraDevice_captureIllegalArgExc__createDefaultCaptureRequestBuilder__release_callsListener() {
+        // GIVEN
+        cameraSource.cameraDevice = cameraDevice
+        whenever(cameraDevice.createCaptureRequest(any()))
+            .doThrow(mock<IllegalArgumentException>())
+
+        // WHEN
+        val listener = mock<OnCameraReadyListener>()
+        cameraSource.createDefaultCaptureRequestBuilder(listener)
+
+        // THEN
+        verify(cameraSource).release()
+        verify(listener).onCameraFailure(any())
     }
 }


### PR DESCRIPTION
https://github.com/brightec/KBarcode/issues/11

This is a complex feature to implement. Rough steps for requesting focus on camera2:
- Cancel the previous repeating request (used for previous and image analysis)
- Cancel any previous focus requests (have to call capture to do this)
- Create a focus request. This is essentially a single capture request with some specific settings for the area of the sensor you want to focus on.
- Restart the repeating request with the focus area also set

Once you complete these steps the camera will actual stay focused on that area of the sensor. Therefore it makes sense to clear that focus a period of time later (5000 millis, copied from camerax. Added ability to set to make it flexible). And resume the automatic focus.

We setup a touch listener within BarcodeView which then calls down eventually into the Camera2Source.

I will update the wiki as needed once this PR is in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/43)
<!-- Reviewable:end -->
