### PR TITLE
Task/scale type rename

### DIFF
--- a/app/src/main/java/uk/co/brightec/kbarcode/app/ProgrammaticActivity.kt
+++ b/app/src/main/java/uk/co/brightec/kbarcode/app/ProgrammaticActivity.kt
@@ -40,7 +40,7 @@ internal class ProgrammaticActivity :
                     )
                 )
                 .barcodesSort(null)
-                .scaleType(BarcodeView.CENTER_INSIDE)
+                .previewScaleType(BarcodeView.CENTER_INSIDE)
                 .clearFocusDelay(BarcodeView.CLEAR_FOCUS_DELAY_DEFAULT)
                 .build()
         )

--- a/app/src/main/res/layout/activity_xml.xml
+++ b/app/src/main/res/layout/activity_xml.xml
@@ -18,7 +18,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:scaleType="centerInside"
+        app:previewScaleType="centerInside"
         app:sort="none"
         app:clearFocusDelay="2000"/>
 

--- a/app/src/main/res/layout/fragment_viewfinder.xml
+++ b/app/src/main/res/layout/fragment_viewfinder.xml
@@ -17,7 +17,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:scaleType="centerCrop"
+        app:previewScaleType="centerCrop"
         app:sort="central" />
 
     <View

--- a/kbarcode/src/androidTest/java/uk/co/brightec/kbarcode/BarcodeViewTest.kt
+++ b/kbarcode/src/androidTest/java/uk/co/brightec/kbarcode/BarcodeViewTest.kt
@@ -334,15 +334,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualWidthTaller_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 100, 250)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -355,15 +356,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualWidthShorter_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 100, 150)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -376,15 +378,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualHeightWider_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 150, 200)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -397,15 +400,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualHeightNarrower_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 50, 200)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -418,15 +422,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualWidthTaller_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 250, 100)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -439,15 +444,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualWidthShorter_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 150, 100)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -460,15 +466,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualHeightWider_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 200, 150)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -481,15 +488,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerInside_viewEqualHeightNarrower_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_INSIDE
+        val previewScaleType = BarcodeView.CENTER_INSIDE
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 200, 50)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -502,15 +510,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualWidthTaller_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 100, 250)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -523,15 +532,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualWidthShorter_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 100, 150)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -544,15 +554,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualHeightWider_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 150, 200)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -565,15 +576,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualHeightNarrower_portrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 50, 200)
         doReturn(true).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -586,15 +598,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualWidthTaller_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 250, 100)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -607,15 +620,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualWidthShorter_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 150, 100)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -628,15 +642,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualHeightWider_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 200, 150)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN
@@ -649,15 +664,16 @@ internal class BarcodeViewTest {
     @Test
     fun centerCrop_viewEqualHeightNarrower_notPortrait__calculateRectForChild__isCorrect() {
         // GIVEN
-        val scaleType = BarcodeView.CENTER_CROP
+        val previewScaleType = BarcodeView.CENTER_CROP
         whenever(barcodeScanner.getOutputSize()).thenReturn(Size(200, 100))
         val viewRect = Rect(0, 0, 200, 50)
         doReturn(false).whenever(barcodeView).isPortraitMode()
 
         // WHEN
         val result = barcodeView.calculateRectForChild(
-            scaleType = scaleType, left = viewRect.left, top = viewRect.top, right = viewRect.right,
-            bottom = viewRect.bottom
+            previewScaleType = previewScaleType,
+            left = viewRect.left, top = viewRect.top,
+            right = viewRect.right, bottom = viewRect.bottom
         )
 
         // THEN

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
@@ -155,8 +155,8 @@ public class BarcodeScanner internal constructor(
         frameProcessor.barcodesSort = comparator
     }
 
-    override fun setPreviewScaleType(@BarcodeView.ScaleType scaleType: Int) {
-        Timber.v("ScaleType has no affect on ${BarcodeScanner::class.java.simpleName}")
+    override fun setPreviewScaleType(@BarcodeView.PreviewScaleType previewScaleType: Int) {
+        Timber.v("PreviewScaleType has no affect on ${BarcodeScanner::class.java.simpleName}")
     }
 
     @Throws(IllegalArgumentException::class)

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeScanner.kt
@@ -155,7 +155,7 @@ public class BarcodeScanner internal constructor(
         frameProcessor.barcodesSort = comparator
     }
 
-    override fun setScaleType(@BarcodeView.ScaleType scaleType: Int) {
+    override fun setPreviewScaleType(@BarcodeView.ScaleType scaleType: Int) {
         Timber.v("ScaleType has no affect on ${BarcodeScanner::class.java.simpleName}")
     }
 

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeView.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeView.kt
@@ -55,7 +55,7 @@ public class BarcodeView @JvmOverloads constructor(
 
     private val surfaceView = SurfaceView(context)
 
-    @ScaleType
+    @PreviewScaleType
     private var _previewScaleType: Int = CENTER_INSIDE
         set(value) {
             field = value
@@ -97,8 +97,8 @@ public class BarcodeView @JvmOverloads constructor(
                 setMinBarcodeWidth(attrMinBarcodeWidth)
                 val attrSort = getInteger(R.styleable.BarcodeView_sort, 0)
                 setBarcodesSort(sortAttrConvert(attrSort))
-                val attrScaleType = getInteger(R.styleable.BarcodeView_previewScaleType, 0)
-                setPreviewScaleType(previewScaleTypeAttrConvert(attrScaleType))
+                val attrPreviewScaleType = getInteger(R.styleable.BarcodeView_previewScaleType, 0)
+                setPreviewScaleType(previewScaleTypeAttrConvert(attrPreviewScaleType))
                 val attrClearFocusDelay = getInteger(
                     R.styleable.BarcodeView_clearFocusDelay,
                     CLEAR_FOCUS_DELAY_DEFAULT.toInt()
@@ -187,8 +187,8 @@ public class BarcodeView @JvmOverloads constructor(
         barcodeScanner.setBarcodesSort(comparator)
     }
 
-    override fun setPreviewScaleType(scaleType: Int) {
-        _previewScaleType = scaleType
+    override fun setPreviewScaleType(previewScaleType: Int) {
+        _previewScaleType = previewScaleType
     }
 
     override fun setClearFocusDelay(delay: Long) {
@@ -197,7 +197,7 @@ public class BarcodeView @JvmOverloads constructor(
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         val childRect = calculateRectForChild(
-            scaleType = _previewScaleType, left = left, top = top, right = right, bottom = bottom
+            previewScaleType = _previewScaleType, left = left, top = top, right = right, bottom = bottom
         )
 
         for (i in 0 until childCount) {
@@ -262,7 +262,7 @@ public class BarcodeView @JvmOverloads constructor(
 
     @VisibleForTesting
     internal fun calculateRectForChild(
-        @ScaleType scaleType: Int,
+        @PreviewScaleType previewScaleType: Int,
         left: Int,
         top: Int,
         right: Int,
@@ -293,13 +293,13 @@ public class BarcodeView @JvmOverloads constructor(
         var childWidth = layoutWidth
         var childHeight = (layoutWidth.toFloat() / width.toFloat() * height).toInt()
 
-        if (scaleType == CENTER_INSIDE) {
+        if (previewScaleType == CENTER_INSIDE) {
             // If height is too tall using fit width, do fit height instead.
             if (childHeight > layoutHeight) {
                 childHeight = layoutHeight
                 childWidth = (layoutHeight.toFloat() / height.toFloat() * width).toInt()
             }
-        } else if (scaleType == CENTER_CROP) {
+        } else if (previewScaleType == CENTER_CROP) {
             // If height is too short using fit width, do fit height instead.
             if (childHeight < layoutHeight) {
                 childHeight = layoutHeight
@@ -355,5 +355,5 @@ public class BarcodeView @JvmOverloads constructor(
         CENTER_CROP
     )
     @Retention(AnnotationRetention.SOURCE)
-    public annotation class ScaleType
+    public annotation class PreviewScaleType
 }

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeView.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/BarcodeView.kt
@@ -56,7 +56,7 @@ public class BarcodeView @JvmOverloads constructor(
     private val surfaceView = SurfaceView(context)
 
     @ScaleType
-    private var previewScaleType: Int = CENTER_INSIDE
+    private var _previewScaleType: Int = CENTER_INSIDE
         set(value) {
             field = value
             requestLayout()
@@ -97,8 +97,8 @@ public class BarcodeView @JvmOverloads constructor(
                 setMinBarcodeWidth(attrMinBarcodeWidth)
                 val attrSort = getInteger(R.styleable.BarcodeView_sort, 0)
                 setBarcodesSort(sortAttrConvert(attrSort))
-                val attrScaleType = getInteger(R.styleable.BarcodeView_scaleType, 0)
-                setScaleType(scaleTypeAttrConvert(attrScaleType))
+                val attrScaleType = getInteger(R.styleable.BarcodeView_previewScaleType, 0)
+                setPreviewScaleType(previewScaleTypeAttrConvert(attrScaleType))
                 val attrClearFocusDelay = getInteger(
                     R.styleable.BarcodeView_clearFocusDelay,
                     CLEAR_FOCUS_DELAY_DEFAULT.toInt()
@@ -187,8 +187,8 @@ public class BarcodeView @JvmOverloads constructor(
         barcodeScanner.setBarcodesSort(comparator)
     }
 
-    override fun setScaleType(scaleType: Int) {
-        previewScaleType = scaleType
+    override fun setPreviewScaleType(scaleType: Int) {
+        _previewScaleType = scaleType
     }
 
     override fun setClearFocusDelay(delay: Long) {
@@ -197,7 +197,7 @@ public class BarcodeView @JvmOverloads constructor(
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         val childRect = calculateRectForChild(
-            scaleType = previewScaleType, left = left, top = top, right = right, bottom = bottom
+            scaleType = _previewScaleType, left = left, top = top, right = right, bottom = bottom
         )
 
         for (i in 0 until childCount) {
@@ -254,7 +254,7 @@ public class BarcodeView @JvmOverloads constructor(
     }
 
     @VisibleForTesting
-    internal fun scaleTypeAttrConvert(attr: Int) = when (attr) {
+    internal fun previewScaleTypeAttrConvert(attr: Int) = when (attr) {
         0 -> CENTER_INSIDE
         1 -> CENTER_CROP
         else -> CENTER_INSIDE

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/KBarcode.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/KBarcode.kt
@@ -43,7 +43,7 @@ public class KBarcode {
 
         public fun setBarcodesSort(comparator: Comparator<Barcode>?)
 
-        public fun setScaleType(@BarcodeView.ScaleType scaleType: Int)
+        public fun setPreviewScaleType(@BarcodeView.ScaleType scaleType: Int)
 
         public fun setClearFocusDelay(delay: Long)
 
@@ -53,7 +53,7 @@ public class KBarcode {
             setBarcodeFormats(options.barcodeFormats)
             setMinBarcodeWidth(options.minBarcodeWidth)
             setBarcodesSort(options.barcodesSort)
-            setScaleType(options.scaleType)
+            setPreviewScaleType(options.previewScaleType)
             setClearFocusDelay(options.clearFocusDelay)
         }
     }

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/KBarcode.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/KBarcode.kt
@@ -43,7 +43,7 @@ public class KBarcode {
 
         public fun setBarcodesSort(comparator: Comparator<Barcode>?)
 
-        public fun setPreviewScaleType(@BarcodeView.ScaleType scaleType: Int)
+        public fun setPreviewScaleType(@BarcodeView.PreviewScaleType previewScaleType: Int)
 
         public fun setClearFocusDelay(delay: Long)
 

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
@@ -12,7 +12,7 @@ public data class Options(
     val barcodeFormats: IntArray = intArrayOf(Barcode.FORMAT_ALL_FORMATS),
     @Px val minBarcodeWidth: Int? = null,
     val barcodesSort: BarcodeComparator? = null,
-    @BarcodeView.ScaleType val previewScaleType: Int,
+    @BarcodeView.PreviewScaleType val previewScaleType: Int,
     val clearFocusDelay: Long
 ) {
 
@@ -22,7 +22,7 @@ public data class Options(
         private var barcodeFormats: IntArray = intArrayOf(Barcode.FORMAT_ALL_FORMATS),
         @Px private var minBarcodeWidth: Int? = null,
         private var barcodesSort: BarcodeComparator? = null,
-        @BarcodeView.ScaleType private var previewScaleType: Int = BarcodeView.CENTER_INSIDE,
+        @BarcodeView.PreviewScaleType private var previewScaleType: Int = BarcodeView.CENTER_INSIDE,
         private var clearFocusDelay: Long = BarcodeView.CLEAR_FOCUS_DELAY_DEFAULT
     ) {
 
@@ -50,8 +50,10 @@ public data class Options(
             this.barcodesSort = barcodesSort
         }
 
-        public fun previewScaleType(@BarcodeView.ScaleType scaleType: Int): Builder = apply {
-            this.previewScaleType = scaleType
+        public fun previewScaleType(
+            @BarcodeView.PreviewScaleType previewScaleType: Int
+        ): Builder = apply {
+            this.previewScaleType = previewScaleType
         }
 
         public fun clearFocusDelay(clearFocusDelay: Long): Builder = apply {

--- a/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
+++ b/kbarcode/src/main/java/uk/co/brightec/kbarcode/Options.kt
@@ -12,7 +12,7 @@ public data class Options(
     val barcodeFormats: IntArray = intArrayOf(Barcode.FORMAT_ALL_FORMATS),
     @Px val minBarcodeWidth: Int? = null,
     val barcodesSort: BarcodeComparator? = null,
-    @BarcodeView.ScaleType val scaleType: Int,
+    @BarcodeView.ScaleType val previewScaleType: Int,
     val clearFocusDelay: Long
 ) {
 
@@ -22,7 +22,7 @@ public data class Options(
         private var barcodeFormats: IntArray = intArrayOf(Barcode.FORMAT_ALL_FORMATS),
         @Px private var minBarcodeWidth: Int? = null,
         private var barcodesSort: BarcodeComparator? = null,
-        @BarcodeView.ScaleType private var scaleType: Int = BarcodeView.CENTER_INSIDE,
+        @BarcodeView.ScaleType private var previewScaleType: Int = BarcodeView.CENTER_INSIDE,
         private var clearFocusDelay: Long = BarcodeView.CLEAR_FOCUS_DELAY_DEFAULT
     ) {
 
@@ -50,8 +50,8 @@ public data class Options(
             this.barcodesSort = barcodesSort
         }
 
-        public fun scaleType(@BarcodeView.ScaleType scaleType: Int): Builder = apply {
-            this.scaleType = scaleType
+        public fun previewScaleType(@BarcodeView.ScaleType scaleType: Int): Builder = apply {
+            this.previewScaleType = scaleType
         }
 
         public fun clearFocusDelay(clearFocusDelay: Long): Builder = apply {
@@ -64,7 +64,7 @@ public data class Options(
             barcodeFormats = barcodeFormats,
             minBarcodeWidth = minBarcodeWidth,
             barcodesSort = barcodesSort,
-            scaleType = scaleType,
+            previewScaleType = previewScaleType,
             clearFocusDelay = clearFocusDelay
         )
     }
@@ -80,7 +80,7 @@ public data class Options(
         if (!barcodeFormats.contentEquals(other.barcodeFormats)) return false
         if (minBarcodeWidth != other.minBarcodeWidth) return false
         if (barcodesSort != other.barcodesSort) return false
-        if (scaleType != other.scaleType) return false
+        if (previewScaleType != other.previewScaleType) return false
         if (clearFocusDelay != other.clearFocusDelay) return false
 
         return true
@@ -92,7 +92,7 @@ public data class Options(
         result = 31 * result + barcodeFormats.contentHashCode()
         result = 31 * result + minBarcodeWidth.hashCode()
         result = 31 * result + (barcodesSort?.hashCode() ?: 0)
-        result = 31 * result + scaleType.hashCode()
+        result = 31 * result + previewScaleType.hashCode()
         result = 31 * result + clearFocusDelay.hashCode()
         return result
     }

--- a/kbarcode/src/main/res/values/attrs.xml
+++ b/kbarcode/src/main/res/values/attrs.xml
@@ -27,7 +27,7 @@
             <enum name="none" value="0" />
             <enum name="central" value="1" />
         </attr>
-        <attr name="scaleType" format="enum">
+        <attr name="previewScaleType" format="enum">
             <enum name="centerInside" value="0" />
             <enum name="centerCrop" value="1" />
         </attr>

--- a/kbarcode/src/test/java/uk/co/brightec/kbarcode/KBarcodeScannerTest.kt
+++ b/kbarcode/src/test/java/uk/co/brightec/kbarcode/KBarcodeScannerTest.kt
@@ -44,7 +44,7 @@ internal class KBarcodeScannerTest {
         verify(barcodeScanner).setBarcodeFormats(options.barcodeFormats)
         verify(barcodeScanner).setMinBarcodeWidth(options.minBarcodeWidth)
         verify(barcodeScanner).setBarcodesSort(options.barcodesSort)
-        verify(barcodeScanner).setScaleType(options.previewScaleType)
+        verify(barcodeScanner).setPreviewScaleType(options.previewScaleType)
         verify(barcodeScanner).setClearFocusDelay(options.clearFocusDelay)
     }
 
@@ -94,7 +94,7 @@ internal class KBarcodeScannerTest {
             // no-op
         }
 
-        override fun setScaleType(scaleType: Int) {
+        override fun setPreviewScaleType(previewScaleType: Int) {
             // no-op
         }
 

--- a/kbarcode/src/test/java/uk/co/brightec/kbarcode/KBarcodeScannerTest.kt
+++ b/kbarcode/src/test/java/uk/co/brightec/kbarcode/KBarcodeScannerTest.kt
@@ -31,7 +31,7 @@ internal class KBarcodeScannerTest {
             on { barcodeFormats } doReturn intArrayOf(1, 2, 3)
             on { minBarcodeWidth } doReturn -2
             on { barcodesSort } doReturn mock()
-            on { scaleType } doReturn -3
+            on { previewScaleType } doReturn -3
             on { clearFocusDelay } doReturn 1234L
         }
 
@@ -44,7 +44,7 @@ internal class KBarcodeScannerTest {
         verify(barcodeScanner).setBarcodeFormats(options.barcodeFormats)
         verify(barcodeScanner).setMinBarcodeWidth(options.minBarcodeWidth)
         verify(barcodeScanner).setBarcodesSort(options.barcodesSort)
-        verify(barcodeScanner).setScaleType(options.scaleType)
+        verify(barcodeScanner).setScaleType(options.previewScaleType)
         verify(barcodeScanner).setClearFocusDelay(options.clearFocusDelay)
     }
 


### PR DESCRIPTION
Based on #44 

Renamed the scaleType attribute to previewScaleType.

This clarifies more precisely what this attribute does. It also means
KBarcode shouldn't clash with camerax lib should you have both
installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/kbarcode/45)
<!-- Reviewable:end -->
